### PR TITLE
Add sticky navigation and update inventory branding

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,8 +1,17 @@
 "use client";
 
+import Image from "next/image";
+import Link from "next/link";
 import { motion } from "framer-motion";
 import { useMemo, useState } from "react";
-import Link from "next/link";
+
+const navLinks = [
+  { label: "Inicio", href: "#hero" },
+  { label: "Sobre nosotros", href: "#sobre-nosotros" },
+  { label: "Inventario", href: "#inventario" },
+  { label: "Marcas", href: "#marcas" },
+  { label: "Contacto", href: "#contacto" },
+];
 
 const heroStats = [
   { label: "Años de trayectoria", value: "20+" },
@@ -14,79 +23,188 @@ const carInventory = [
   {
     brand: "Toyota",
     tagline: "Tecnología híbrida y la confiabilidad japonesa",
-    highlight: "Curaduría Machine para uso urbano",
+    highlight: "Curaduría Machine para uso urbano y aventuras familiares",
     vehicles: [
       {
         model: "Corolla SEG Hybrid",
         year: 2023,
         price: "USD 29.800",
+        description:
+          "Sedán híbrido full con asistencia Toyota Safety Sense y consumo promedio de 4,5 l/100 km.",
         details: ["Automático CVT", "18.200 km", "Garantía oficial vigente"],
+        image: "/vehicles/toyota-lineup.svg",
       },
       {
         model: "SW4 SRX",
         year: 2022,
         price: "USD 64.500",
-        details: ["4x4", "Service oficial al día", "Pack seguridad Toyota Safety Sense"],
-      },
-    ],
-  },
-  {
-    brand: "BMW",
-    tagline: "Performance con ADN deportivo Machine",
-    highlight: "Unidades certificadas con historial completo",
-    vehicles: [
-      {
-        model: "330i M Sport",
-        year: 2021,
-        price: "USD 52.900",
-        details: ["Paquete M Performance", "26.000 km", "Llantas 19\" diamantadas"],
-      },
-      {
-        model: "X1 sDrive 20i",
-        year: 2022,
-        price: "USD 44.200",
-        details: ["Nuevo diseño xLine", "17.500 km", "Techo panorámico"],
-      },
-    ],
-  },
-  {
-    brand: "Mercedes-Benz",
-    tagline: "Lujo urbano con estilo Machine",
-    highlight: "Garantía extendida + detailing premium",
-    vehicles: [
-      {
-        model: "GLA 200 Progressive",
-        year: 2022,
-        price: "USD 47.500",
-        details: ["Motor turbo 163 cv", "20.300 km", "MBUX con realidad aumentada"],
-      },
-      {
-        model: "C 300 AMG-Line",
-        year: 2021,
-        price: "USD 59.900",
-        details: ["Suspensión adaptativa", "32.000 km", "Interior AMG Artico"],
+        description:
+          "SUV 7 asientos con tracción 4x4 permanente, ideal para viajes largos y uso off-road premium.",
+        details: ["4x4", "Service oficial al día", "Pack Toyota Safety Sense"],
+        image: "/vehicles/toyota-lineup.svg",
       },
     ],
   },
   {
     brand: "Ford",
-    tagline: "Pickups y muscle cars listos para rodar",
-    highlight: "Vehículos listos para trabajar o disfrutar",
+    tagline: "Innovación americana para cada desafío",
+    highlight: "Vehículos listos para trabajar, explorar y disfrutar el camino",
     vehicles: [
       {
         model: "Bronco Sport Wildtrak",
         year: 2023,
         price: "USD 54.800",
+        description:
+          "4x4 con modo GOAT, llantas beadlock y paquete de asistencia para senderos extremos.",
         details: ["Tracción 4x4 GOAT", "9.400 km", "Motor EcoBoost 2.0"],
+        image: "/vehicles/ford-lineup.svg",
       },
       {
         model: "Mustang GT Premium",
         year: 2020,
         price: "USD 69.000",
+        description:
+          "Coupé V8 con paquete Performance y escape activo, calibrado por nuestro equipo Machine.",
         details: ["V8 5.0 460 cv", "22.000 km", "Modo Track + Launch Control"],
+        image: "/vehicles/ford-lineup.svg",
       },
     ],
   },
+  {
+    brand: "Fiat",
+    tagline: "Eficiencia urbana con actitud aventurera",
+    highlight: "Unidades compactas certificadas y listas para financiar al instante",
+    vehicles: [
+      {
+        model: "Pulse Impetus Turbo",
+        year: 2023,
+        price: "USD 25.400",
+        description:
+          "SUV compacto con motor turbo 1.0, ADAS nivel 1 y conectividad completa Fiat Connect Me.",
+        details: ["Caja CVT", "12.600 km", "Techo bitono"],
+        image: "/vehicles/fiat-lineup.svg",
+      },
+      {
+        model: "Cronos Precision",
+        year: 2022,
+        price: "USD 18.900",
+        description:
+          "Sedán producido en Córdoba con pantalla Uconnect 7\" y mantenimiento programado incluido.",
+        details: ["Motor 1.8 E.torQ", "24.300 km", "Pantalla Uconnect 7\""],
+        image: "/vehicles/fiat-lineup.svg",
+      },
+    ],
+  },
+  {
+    brand: "Audi",
+    tagline: "Performance con ADN deportivo",
+    highlight: "Curaduría premium con historial digitalizado de cada unidad",
+    vehicles: [
+      {
+        model: "Q5 45 TFSI quattro",
+        year: 2022,
+        price: "USD 58.200",
+        description:
+          "SUV híbrido ligero con quattro ultra y asistente de conducción Audi pre sense front.",
+        details: ["Suspensión adaptativa", "21.800 km", "Sonido Bang & Olufsen"],
+        image: "/vehicles/audi-lineup.svg",
+      },
+      {
+        model: "A3 Sportback S line",
+        year: 2021,
+        price: "USD 36.900",
+        description:
+          "Hatchback turbo con paquete S line, Virtual Cockpit y historial de mantenimiento certificado.",
+        details: ["Motor 1.4 TFSI", "28.400 km", "Faros Matrix LED"],
+        image: "/vehicles/audi-lineup.svg",
+      },
+    ],
+  },
+  {
+    brand: "Jeep",
+    tagline: "Aventura y sofisticación en un mismo ADN",
+    highlight: "Pre-entrega Machine con detailing cerámico y protección off-road",
+    vehicles: [
+      {
+        model: "Compass Limited Plus",
+        year: 2023,
+        price: "USD 43.700",
+        description:
+          "SUV mediano con ADAS completo, 4x4 on demand y tapizados en cuero premium.",
+        details: ["Motor 1.3 Turbo", "15.800 km", "Uconnect 10\""],
+        image: "/vehicles/jeep-lineup.svg",
+      },
+      {
+        model: "Gladiator Rubicon",
+        year: 2022,
+        price: "USD 78.900",
+        description:
+          "Pickup con ejes Dana 44, neumáticos Mud Terrain y winche Warn instalado por Machine.",
+        details: ["Caja automática 8 vel.", "19.500 km", "Trail Rated"],
+        image: "/vehicles/jeep-lineup.svg",
+      },
+    ],
+  },
+  {
+    brand: "Renault",
+    tagline: "Ingeniería francesa adaptada a tu negocio",
+    highlight: "Garantía certificada y programas de mantenimiento predictivo",
+    vehicles: [
+      {
+        model: "Alaskan Intens 4x4",
+        year: 2022,
+        price: "USD 44.300",
+        description:
+          "Pickup doble cabina con 4x4 low, caja automática y cobertura ExtendCare 3 años.",
+        details: ["Motor 2.3 biturbo", "27.600 km", "Multimedia Easy Link"],
+        image: "/vehicles/renault-lineup.svg",
+      },
+      {
+        model: "Stepway Intens",
+        year: 2023,
+        price: "USD 19.800",
+        description:
+          "Crossover urbano con ESP, carrocería elevada y pack multimedia con cámara HD.",
+        details: ["Motor 1.6 SCe", "9.800 km", "Sistema Media Evolution"],
+        image: "/vehicles/renault-lineup.svg",
+      },
+    ],
+  },
+  {
+    brand: "Peugeot",
+    tagline: "Diseño francés con tecnología de vanguardia",
+    highlight: "Selección boutique con protocolos de detailing y software actualizado",
+    vehicles: [
+      {
+        model: "3008 GT Pack Hybrid4",
+        year: 2022,
+        price: "USD 52.400",
+        description:
+          "SUV plug-in hybrid con 300 cv, i-Cockpit y asistencia semiautónoma nivel 2.",
+        details: ["Tracción AWD", "23.100 km", "Tapizados Nappa"],
+        image: "/vehicles/peugeot-lineup.svg",
+      },
+      {
+        model: "208 GT Line",
+        year: 2023,
+        price: "USD 26.700",
+        description:
+          "Hatchback producido en El Palomar con i-Cockpit 3D y paquete ADAS Drive Assist.",
+        details: ["Motor 1.2 PureTech", "11.400 km", "Full LED"],
+        image: "/vehicles/peugeot-lineup.svg",
+      },
+    ],
+  },
+];
+
+const brandLogos = [
+  { name: "Ford", image: "/logos/ford.svg" },
+  { name: "Fiat", image: "/logos/fiat.svg" },
+  { name: "Audi", image: "/logos/audi.svg" },
+  { name: "Jeep", image: "/logos/jeep.svg" },
+  { name: "Toyota", image: "/logos/toyota.svg" },
+  { name: "Renault", image: "/logos/renault.svg" },
+  { name: "Peugeot", image: "/logos/peugeot.svg" },
 ];
 
 const contactTemplates = [
@@ -122,248 +240,80 @@ export default function Home() {
   );
 
   return (
-    <main className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-20 px-4 pb-32 pt-10 sm:px-8 lg:px-0">
-      <section className="relative overflow-hidden rounded-[40px] border border-white/10 bg-gradient-to-br from-[#f1c40f]/90 via-[#f39c12]/80 to-[#34495e]/90 p-[1px]">
-        <div className="relative h-full w-full rounded-[38px] bg-[#050a0e]/90 px-6 py-12 sm:px-12">
-          <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(241,196,15,0.35),_transparent_55%)]" />
-          <motion.div
-            initial={{ opacity: 0, y: 40 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, ease: "easeOut" }}
-            className="flex flex-col gap-10 lg:flex-row lg:items-center"
-          >
-            <div className="flex-1 space-y-6">
-              <span className="glass-chip">CONCESIONARIA MACHINE</span>
-              <h1 className="text-balance text-4xl font-semibold tracking-tight text-white sm:text-5xl lg:text-6xl">
-                El garaje boutique para los que aman manejar.
-              </h1>
-              <p className="text-pretty text-lg text-white/80 sm:max-w-xl">
-                Autos seleccionados uno a uno, procesos digitales y un equipo obsesionado con cada detalle. Comprá, vendé o permutá en una experiencia 100% Machine.
-              </p>
-              <div className="flex flex-wrap items-center gap-4">
-                <Link href="#inventario" className="glass-button">
-                  Ver inventario
-                  <svg
-                    className="ml-2 h-4 w-4"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <path d="M5 12h14" />
-                    <path d="m12 5 7 7-7 7" />
-                  </svg>
-                </Link>
-                <Link
-                  href="#contacto"
-                  className="inline-flex items-center gap-2 rounded-full border border-white/15 px-6 py-3 text-sm font-semibold text-white/80 transition hover:border-white/30 hover:text-white"
-                >
-                  Hablar con un asesor
-                  <svg
-                    className="h-4 w-4"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <path d="M8 5h13" />
-                    <path d="M8 12h13" />
-                    <path d="M8 19h13" />
-                    <path d="M3 5h.01" />
-                    <path d="M3 12h.01" />
-                    <path d="M3 19h.01" />
-                  </svg>
-                </Link>
-              </div>
+    <div className="relative">
+      <header className="fixed inset-x-0 top-0 z-50 border-b border-white/10 bg-[#050a0e]/80 backdrop-blur-xl">
+        <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-4 sm:px-8 lg:px-0">
+          <Link href="#hero" className="flex items-center gap-3 text-white">
+            <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-[#f1c40f]/20 text-lg font-semibold text-[#f1c40f]">
+              M
+            </span>
+            <div className="flex flex-col leading-tight">
+              <span className="text-sm uppercase tracking-[0.4em] text-white/60">Machine 5900</span>
+              <span className="text-lg font-semibold text-white">Garage Boutique</span>
             </div>
-            <motion.div
-              initial={{ opacity: 0, scale: 0.9 }}
-              animate={{ opacity: 1, scale: 1 }}
-              transition={{ duration: 0.7, delay: 0.2, ease: "easeOut" }}
-              className="section-card flex-1 space-y-6 p-8"
-            >
-              <h2 className="text-lg font-semibold text-white">Machine Experience</h2>
-              <p className="text-sm text-white/70">
-                Coordinamos la experiencia completa: detailing premium, gestoría express, entrega en el día y seguimiento post venta.
-              </p>
-              <div className="grid grid-cols-1 gap-6 sm:grid-cols-3">
-                {heroStats.map((stat) => (
-                  <div key={stat.label} className="rounded-2xl bg-white/5 p-4 text-center shadow-inner shadow-black/30">
-                    <p className="text-3xl font-semibold text-[#f1c40f]">{stat.value}</p>
-                    <p className="text-xs uppercase tracking-[0.2em] text-white/60">{stat.label}</p>
-                  </div>
-                ))}
-              </div>
-            </motion.div>
-          </motion.div>
-        </div>
-      </section>
-
-      <section id="sobre-nosotros" className="section-card relative overflow-hidden px-8 py-12 sm:px-12">
-        <div className="absolute inset-0 -z-10 bg-gradient-to-br from-white/5 via-transparent to-white/0" />
-        <motion.div
-          initial={{ opacity: 0, y: 24 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true, amount: 0.2 }}
-          transition={{ duration: 0.6, ease: "easeOut" }}
-          className="grid gap-10 lg:grid-cols-[1fr_0.8fr]"
-        >
-          <div className="space-y-6">
-            <span className="glass-chip">SOBRE NOSOTROS</span>
-            <h2 className="text-3xl font-semibold text-white sm:text-4xl">Empresa, objetivos y ADN Machine</h2>
-            <p className="text-pretty text-base text-white/70">
-              Nacimos como un garaje boutique especializado en vehículos deportivos y premium. Dos décadas después seguimos con la misma obsesión: encontrar la unidad perfecta para cada cliente y acompañarlo en todo el recorrido.
-            </p>
-            <div className="grid gap-6 sm:grid-cols-2">
-              <div className="rounded-2xl border border-white/10 bg-[#f1c40f]/10 p-6 shadow-inner shadow-[#f1c40f]/30">
-                <h3 className="text-lg font-semibold text-[#f1c40f]">Objetivos 2024</h3>
-                <ul className="mt-4 space-y-3 text-sm text-white/80">
-                  <li className="flex items-start gap-2">
-                    <span className="mt-1 inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-[#f1c40f]" />
-                    Expandir la oferta electrificada y híbrida.
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <span className="mt-1 inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-[#f1c40f]" />
-                    Lanzar la membresía Machine Club con beneficios exclusivos.
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <span className="mt-1 inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-[#f1c40f]" />
-                    Reducir tiempos de entrega a menos de 48 horas.
-                  </li>
-                </ul>
-              </div>
-              <div className="rounded-2xl border border-white/10 bg-white/5 p-6">
-                <h3 className="text-lg font-semibold text-white">Nuestro diferencial</h3>
-                <ul className="mt-4 space-y-4 text-sm text-white/70">
-                  <li className="flex items-center gap-3">
-                    <span className="flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-[#f1c40f]">AI</span>
-                    Diagnóstico técnico asistido por inteligencia artificial.
-                  </li>
-                  <li className="flex items-center gap-3">
-                    <span className="flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-[#f1c40f]">VR</span>
-                    Recorridos virtuales y seguimiento online de cada unidad.
-                  </li>
-                  <li className="flex items-center gap-3">
-                    <span className="flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-[#f1c40f]">24H</span>
-                    Asesoramiento personalizado 24/7 vía WhatsApp Business.
-                  </li>
-                </ul>
-              </div>
-            </div>
-          </div>
-          <div className="space-y-6">
-            <div className="rounded-3xl border border-white/10 bg-gradient-to-br from-white/10 via-transparent to-transparent p-8">
-              <p className="text-lg text-white/80">
-                “Machine nació para hacer fácil algo que suele ser complejo. Si estás comprando, sabemos que querés emoción y seguridad. Si estás vendiendo, buscás agilidad y confianza. Nuestro equipo combina datos, tecnología y pasión por los autos para superar esa expectativa.”
-              </p>
-              <div className="mt-6 flex items-center gap-3 text-sm text-white/60">
-                <span className="font-semibold text-white">Marcos Cabrera</span>
-                · Director Comercial Machine 5900
-              </div>
-            </div>
-            <div className="grid gap-4 sm:grid-cols-3">
-              {[
-                { label: "Gestoría", value: "48 hs" },
-                { label: "Detalle premium", value: "Incluido" },
-                { label: "Cobertura", value: "Nacional" },
-              ].map((item) => (
-                <div key={item.label} className="rounded-2xl border border-white/10 bg-white/5 p-4 text-center">
-                  <p className="text-sm uppercase tracking-[0.2em] text-white/60">{item.label}</p>
-                  <p className="mt-2 text-2xl font-semibold text-white">{item.value}</p>
-                </div>
-              ))}
-            </div>
-          </div>
-        </motion.div>
-      </section>
-
-      <section id="inventario" className="space-y-10">
-        <div className="flex flex-col gap-4">
-          <span className="glass-chip">LOS AUTOS DISPONIBLES</span>
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-            <h2 className="text-3xl font-semibold text-white sm:text-4xl">Descubrí por marca</h2>
-            <p className="text-sm text-white/60">
-              Stock actualizado y chequeado diariamente. Seleccioná la marca para ver unidades destacadas.
-            </p>
-          </div>
-        </div>
-        <motion.div
-          initial="hidden"
-          whileInView="visible"
-          viewport={{ once: true, amount: 0.2 }}
-          variants={{
-            hidden: { opacity: 0, y: 30 },
-            visible: {
-              opacity: 1,
-              y: 0,
-              transition: { duration: 0.6, ease: "easeOut" },
-            },
-          }}
-          className="section-card space-y-8 px-6 py-8 sm:px-10"
-        >
-          <div className="flex flex-wrap gap-3">
-            {carInventory.map((brand) => (
-              <button
-                key={brand.brand}
-                type="button"
-                onClick={() => setSelectedBrand(brand.brand)}
-                className={`flex items-center gap-2 rounded-full border px-5 py-2 text-sm font-semibold transition-all duration-300 ${
-                  selectedBrand === brand.brand
-                    ? "border-[#f1c40f]/80 bg-[#f1c40f]/20 text-white"
-                    : "border-white/10 bg-white/5 text-white/70 hover:border-white/30 hover:text-white"
-                }`}
+          </Link>
+          <nav className="hidden items-center gap-6 text-sm font-medium text-white/70 md:flex">
+            {navLinks.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="transition hover:text-white"
               >
-                <span className="h-2 w-2 rounded-full bg-[#f1c40f]" />
-                {brand.brand}
-              </button>
+                {link.label}
+              </Link>
             ))}
-          </div>
-          <div className="grid gap-8 lg:grid-cols-[1fr_1.3fr]">
-            <div className="space-y-4">
-              <p className="text-sm font-semibold uppercase tracking-[0.25em] text-[#f1c40f]/80">
-                {activeBrand.brand}
-              </p>
-              <h3 className="text-2xl font-semibold text-white">{activeBrand.tagline}</h3>
-              <p className="text-sm text-white/70">{activeBrand.highlight}</p>
-              <div className="flex flex-wrap gap-3 text-sm text-white/60">
-                <span className="rounded-full border border-white/10 px-4 py-1">Financiación flexible</span>
-                <span className="rounded-full border border-white/10 px-4 py-1">Toma de usado</span>
-                <span className="rounded-full border border-white/10 px-4 py-1">Entrega inmediata</span>
-              </div>
-            </div>
-            <div className="grid gap-6 sm:grid-cols-2">
-              {activeBrand.vehicles.map((vehicle) => (
-                <motion.article
-                  key={vehicle.model}
-                  whileHover={{ y: -6 }}
-                  className="group flex flex-col justify-between rounded-3xl border border-white/10 bg-white/5 p-6 shadow-[0_25px_60px_-35px_rgba(0,0,0,0.65)]"
-                >
-                  <div className="space-y-3">
-                    <div className="flex items-center justify-between text-xs text-white/60">
-                      <span>{vehicle.year}</span>
-                      <span className="rounded-full bg-[#f1c40f]/20 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-[#f1c40f]">
-                        Premium
-                      </span>
-                    </div>
-                    <h4 className="text-xl font-semibold text-white">{vehicle.model}</h4>
-                    <p className="text-lg font-semibold text-[#f1c40f]">{vehicle.price}</p>
-                    <ul className="space-y-2 text-sm text-white/70">
-                      {vehicle.details.map((detail) => (
-                        <li key={detail} className="flex items-center gap-2">
-                          <span className="h-1.5 w-1.5 rounded-full bg-[#f1c40f]" />
-                          {detail}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                  <button className="mt-6 inline-flex items-center justify-between rounded-full border border-white/10 bg-[#34495e]/60 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-white/80 transition hover:border-[#f1c40f]/40 hover:text-white">
-                    Ver ficha completa
+          </nav>
+          <Link
+            href="#contacto"
+            className="glass-button hidden text-sm md:inline-flex"
+          >
+            Pedir asesor
+          </Link>
+          <Link
+            href="#contacto"
+            className="glass-button text-xs md:hidden"
+          >
+            Contacto
+          </Link>
+        </div>
+      </header>
+
+      <main
+        id="hero"
+        className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-20 px-4 pb-32 pt-32 sm:px-8 lg:px-0"
+      >
+        <section className="relative overflow-hidden rounded-[40px] border border-white/10 bg-gradient-to-br from-[#f1c40f]/90 via-[#f39c12]/80 to-[#34495e]/90 p-[1px]">
+          <div className="relative h-full w-full rounded-[38px] bg-[#050a0e]/90 px-6 py-12 sm:px-12">
+            <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(241,196,15,0.35),_transparent_55%)]" />
+            <motion.div
+              initial={{ opacity: 0, y: 40 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, ease: "easeOut" }}
+              className="flex flex-col gap-10 lg:flex-row lg:items-center"
+            >
+              <div className="flex-1 space-y-6">
+                <span className="glass-chip">CONCESIONARIA MACHINE</span>
+                <h1 className="text-balance text-4xl font-semibold tracking-tight text-white sm:text-5xl lg:text-6xl">
+                  El garaje boutique para los que aman manejar.
+                </h1>
+                <p className="text-pretty text-lg text-white/80 sm:max-w-xl">
+                  Autos seleccionados uno a uno, procesos digitales y un equipo obsesionado con cada detalle. Comprá, vendé o permutá en una experiencia 100% Machine.
+                </p>
+                <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 shadow-[0_25px_60px_-35px_rgba(0,0,0,0.65)]">
+                  <Image
+                    src="/images/hero-garage.svg"
+                    alt="Showroom boutique de Machine con un deportivo iluminado"
+                    width={960}
+                    height={640}
+                    priority
+                    className="h-full w-full object-cover"
+                  />
+                </div>
+                <div className="flex flex-wrap items-center gap-4">
+                  <Link href="#inventario" className="glass-button">
+                    Ver inventario
                     <svg
-                      className="h-4 w-4"
+                      className="ml-2 h-4 w-4"
                       viewBox="0 0 24 24"
                       fill="none"
                       stroke="currentColor"
@@ -374,132 +324,225 @@ export default function Home() {
                       <path d="M5 12h14" />
                       <path d="m12 5 7 7-7 7" />
                     </svg>
-                  </button>
-                </motion.article>
-              ))}
-            </div>
+                  </Link>
+                  <Link
+                    href="#contacto"
+                    className="inline-flex items-center gap-2 rounded-full border border-white/15 px-6 py-3 text-sm font-semibold text-white/80 transition hover:border-white/30 hover:text-white"
+                  >
+                    Hablar con un asesor
+                    <svg
+                      className="h-4 w-4"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <path d="M8 5h13" />
+                      <path d="M8 12h13" />
+                      <path d="M8 19h13" />
+                      <path d="M3 5h.01" />
+                      <path d="M3 12h.01" />
+                      <path d="M3 19h.01" />
+                    </svg>
+                  </Link>
+                </div>
+              </div>
+              <motion.div
+                initial={{ opacity: 0, scale: 0.9 }}
+                animate={{ opacity: 1, scale: 1 }}
+                transition={{ duration: 0.7, delay: 0.2, ease: "easeOut" }}
+                className="section-card flex-1 space-y-6 p-8"
+              >
+                <h2 className="text-lg font-semibold text-white">Machine Experience</h2>
+                <p className="text-sm text-white/70">
+                  Coordinamos la experiencia completa: detailing premium, gestoría express, entrega en el día y seguimiento post venta.
+                </p>
+                <div className="grid grid-cols-1 gap-6 sm:grid-cols-3">
+                  {heroStats.map((stat) => (
+                    <div key={stat.label} className="rounded-2xl bg-white/5 p-4 text-center shadow-inner shadow-black/30">
+                      <p className="text-3xl font-semibold text-[#f1c40f]">{stat.value}</p>
+                      <p className="text-xs uppercase tracking-[0.2em] text-white/60">{stat.label}</p>
+                    </div>
+                  ))}
+                </div>
+              </motion.div>
+            </motion.div>
           </div>
-        </motion.div>
-      </section>
+        </section>
 
-      <section id="contacto" className="space-y-10">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-          <div>
-            <span className="glass-chip">CONTACTO</span>
-            <h2 className="mt-4 text-3xl font-semibold text-white sm:text-4xl">Conectá con Machine</h2>
-          </div>
-          <p className="max-w-xl text-sm text-white/60">
-            Elegí la vía que prefieras: escribinos directo por WhatsApp, enviá un formulario o usá nuestras plantillas inteligentes para acelerar tu consulta.
-          </p>
-        </div>
-        <div className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr]">
+        <section id="sobre-nosotros" className="section-card relative overflow-hidden px-8 py-12 sm:px-12">
+          <div className="absolute inset-0 -z-10 bg-gradient-to-br from-white/5 via-transparent to-white/0" />
           <motion.div
-            initial={{ opacity: 0, y: 30 }}
+            initial={{ opacity: 0, y: 24 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true, amount: 0.2 }}
             transition={{ duration: 0.6, ease: "easeOut" }}
-            className="section-card px-8 py-10"
+            className="grid gap-10 lg:grid-cols-[1fr_0.8fr]"
           >
-            <h3 className="text-xl font-semibold text-white">Armemos tu plan a medida</h3>
-            <p className="mt-2 text-sm text-white/70">
-              Completá el formulario y un asesor Machine te responde en menos de 30 minutos hábiles.
-            </p>
-            <form className="mt-8 space-y-5">
-              <div>
-                <label className="text-xs font-semibold uppercase tracking-[0.2em] text-white/50">Nombre y apellido</label>
-                <input
-                  type="text"
-                  required
-                  placeholder="Juan Pérez"
-                  className="mt-2 w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-[#f1c40f]/60 focus:outline-none"
-                />
-              </div>
-              <div className="grid gap-5 sm:grid-cols-2">
-                <div>
-                  <label className="text-xs font-semibold uppercase tracking-[0.2em] text-white/50">Email</label>
-                  <input
-                    type="email"
-                    required
-                    placeholder="mail@machine.com"
-                    className="mt-2 w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-[#f1c40f]/60 focus:outline-none"
-                  />
+            <div className="space-y-6">
+              <span className="glass-chip">SOBRE NOSOTROS</span>
+              <h2 className="text-3xl font-semibold text-white sm:text-4xl">Veinte años construyendo confianza</h2>
+              <p className="text-pretty text-base text-white/70">
+                Nacimos como un garaje boutique especializado en vehículos deportivos y premium. Dos décadas después seguimos con la misma obsesión: encontrar la unidad perfecta para cada cliente y acompañarlo en todo el recorrido.
+              </p>
+              <div className="grid gap-6 sm:grid-cols-2">
+                <div className="rounded-2xl border border-white/10 bg-[#f1c40f]/10 p-6 shadow-inner shadow-[#f1c40f]/30">
+                  <h3 className="text-lg font-semibold text-[#f1c40f]">Historia Machine</h3>
+                  <ul className="mt-4 space-y-3 text-sm text-white/80">
+                    <li className="flex items-start gap-2">
+                      <span className="mt-1 inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-[#f1c40f]" />
+                      Apertura del primer showroom boutique en Palermo en 2004.
+                    </li>
+                    <li className="flex items-start gap-2">
+                      <span className="mt-1 inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-[#f1c40f]" />
+                      Equipo interno de tasación y detailing certificado por fabricantes premium.
+                    </li>
+                    <li className="flex items-start gap-2">
+                      <span className="mt-1 inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-[#f1c40f]" />
+                      Red nacional de entregas puerta a puerta con logística asegurada.
+                    </li>
+                  </ul>
                 </div>
-                <div>
-                  <label className="text-xs font-semibold uppercase tracking-[0.2em] text-white/50">Teléfono</label>
-                  <input
-                    type="tel"
-                    required
-                    placeholder="11 5555 5555"
-                    className="mt-2 w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-[#f1c40f]/60 focus:outline-none"
-                  />
+                <div className="rounded-2xl border border-white/10 bg-white/5 p-6">
+                  <h3 className="text-lg font-semibold text-white">Nuestro diferencial</h3>
+                  <ul className="mt-4 space-y-4 text-sm text-white/70">
+                    <li className="flex items-center gap-3">
+                      <span className="flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-[#f1c40f]">AI</span>
+                      Diagnóstico técnico asistido por inteligencia artificial.
+                    </li>
+                    <li className="flex items-center gap-3">
+                      <span className="flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-[#f1c40f]">VR</span>
+                      Recorridos virtuales y seguimiento online de cada unidad.
+                    </li>
+                    <li className="flex items-center gap-3">
+                      <span className="flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-[#f1c40f]">24H</span>
+                      Asesoramiento personalizado 24/7 vía WhatsApp Business.
+                    </li>
+                  </ul>
                 </div>
               </div>
-              <div>
-                <label className="text-xs font-semibold uppercase tracking-[0.2em] text-white/50">Interés</label>
-                <select
-                  defaultValue="comprar"
-                  className="mt-2 w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white focus:border-[#f1c40f]/60 focus:outline-none"
-                >
-                  <option value="comprar">Quiero comprar</option>
-                  <option value="vender">Quiero vender</option>
-                  <option value="tasar">Quiero tasar</option>
-                  <option value="test-drive">Agendar test drive</option>
-                </select>
+            </div>
+            <div className="space-y-6">
+              <div className="rounded-3xl border border-white/10 bg-gradient-to-br from-white/10 via-transparent to-transparent p-8">
+                <p className="text-lg text-white/80">
+                  “Machine nació para hacer fácil algo que suele ser complejo. Si estás comprando, sabemos que querés emoción y seguridad. Si estás vendiendo, buscás agilidad y confianza. Nuestro equipo combina datos, tecnología y pasión por los autos para superar esa expectativa.”
+                </p>
+                <div className="mt-6 flex items-center gap-3 text-sm text-white/60">
+                  <span className="font-semibold text-white">Marcos Cabrera</span>
+                  · Director Comercial Machine 5900
+                </div>
               </div>
-              <div>
-                <label className="text-xs font-semibold uppercase tracking-[0.2em] text-white/50">Mensaje</label>
-                <textarea
-                  rows={4}
-                  placeholder="Contanos en qué unidad estás interesado y cómo preferís que te contactemos."
-                  className="mt-2 w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-[#f1c40f]/60 focus:outline-none"
-                />
+              <div className="grid gap-4 sm:grid-cols-3">
+                {[
+                  { label: "Gestoría", value: "48 hs" },
+                  { label: "Detalle premium", value: "Incluido" },
+                  { label: "Cobertura", value: "Nacional" },
+                ].map((item) => (
+                  <div key={item.label} className="rounded-2xl border border-white/10 bg-white/5 p-4 text-center">
+                    <p className="text-sm uppercase tracking-[0.2em] text-white/60">{item.label}</p>
+                    <p className="mt-2 text-2xl font-semibold text-white">{item.value}</p>
+                  </div>
+                ))}
               </div>
-              <button type="submit" className="glass-button w-full justify-center">
-                Enviar consulta
-                <svg
-                  className="ml-2 h-4 w-4"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <path d="m5 12 7-7 7 7" />
-                </svg>
-              </button>
-            </form>
+            </div>
           </motion.div>
+        </section>
 
-          <motion.div
-            initial={{ opacity: 0, y: 30 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, amount: 0.2 }}
-            transition={{ duration: 0.6, ease: "easeOut", delay: 0.1 }}
-            className="section-card flex flex-col gap-6 px-8 py-10"
-          >
-            <div>
-              <h3 className="text-xl font-semibold text-white">Plantillas inteligentes</h3>
-              <p className="mt-2 text-sm text-white/70">
-                Seleccioná una plantilla y abrí tu servicio de mail favorito con el mensaje listo para enviar.
+        <section id="inventario" className="space-y-10">
+          <div className="flex flex-col gap-4">
+            <span className="glass-chip">LOS AUTOS DISPONIBLES</span>
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+              <h2 className="text-3xl font-semibold text-white sm:text-4xl">Descubrí por marca</h2>
+              <p className="text-sm text-white/60">
+                Stock actualizado y chequeado diariamente. Seleccioná la marca para ver unidades destacadas.
               </p>
             </div>
-            <div className="space-y-4">
-              {contactTemplates.map((template) => {
-                const query = new URLSearchParams({
-                  subject: template.subject,
-                  body: template.body,
-                }).toString();
-
-                return (
-                  <div key={template.title} className="rounded-2xl border border-white/10 bg-white/5 p-5">
-                    <h4 className="text-lg font-semibold text-white">{template.title}</h4>
-                    <p className="mt-2 text-sm text-white/70">{template.description}</p>
-                    <a
-                      href={`mailto:ventas@machine5900.com.ar?${query}`}
-                      className="mt-4 inline-flex items-center gap-2 rounded-full border border-white/15 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-[#f1c40f] transition hover:border-[#f1c40f]/50 hover:text-white"
-                    >
-                      Usar plantilla
+          </div>
+          <motion.div
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true, amount: 0.2 }}
+            variants={{
+              hidden: { opacity: 0, y: 30 },
+              visible: {
+                opacity: 1,
+                y: 0,
+                transition: { duration: 0.6, ease: "easeOut" },
+              },
+            }}
+            className="section-card space-y-8 px-6 py-8 sm:px-10"
+          >
+            <div className="flex flex-wrap gap-3">
+              {carInventory.map((brand) => (
+                <button
+                  key={brand.brand}
+                  type="button"
+                  onClick={() => setSelectedBrand(brand.brand)}
+                  className={`flex items-center gap-2 rounded-full border px-5 py-2 text-sm font-semibold transition-all duration-300 ${
+                    selectedBrand === brand.brand
+                      ? "border-[#f1c40f]/80 bg-[#f1c40f]/20 text-white"
+                      : "border-white/10 bg-white/5 text-white/70 hover:border-white/30 hover:text-white"
+                  }`}
+                >
+                  <span className="h-2 w-2 rounded-full bg-[#f1c40f]" />
+                  {brand.brand}
+                </button>
+              ))}
+            </div>
+            <div className="grid gap-8 lg:grid-cols-[1fr_1.3fr]">
+              <div className="space-y-4">
+                <p className="text-sm font-semibold uppercase tracking-[0.25em] text-[#f1c40f]/80">
+                  {activeBrand.brand}
+                </p>
+                <h3 className="text-2xl font-semibold text-white">{activeBrand.tagline}</h3>
+                <p className="text-sm text-white/70">{activeBrand.highlight}</p>
+                <div className="flex flex-wrap gap-3 text-sm text-white/60">
+                  <span className="rounded-full border border-white/10 px-4 py-1">Financiación flexible</span>
+                  <span className="rounded-full border border-white/10 px-4 py-1">Toma de usado</span>
+                  <span className="rounded-full border border-white/10 px-4 py-1">Entrega inmediata</span>
+                </div>
+              </div>
+              <div className="grid gap-6 sm:grid-cols-2">
+                {activeBrand.vehicles.map((vehicle) => (
+                  <motion.article
+                    key={vehicle.model}
+                    whileHover={{ y: -6 }}
+                    className="group flex h-full flex-col justify-between rounded-3xl border border-white/10 bg-white/5 p-6 shadow-[0_25px_60px_-35px_rgba(0,0,0,0.65)]"
+                  >
+                    <div className="space-y-4">
+                      <div className="relative h-44 overflow-hidden rounded-2xl border border-white/10">
+                        <Image
+                          src={vehicle.image}
+                          alt={`Imagen ilustrativa del ${vehicle.model}`}
+                          fill
+                          sizes="(min-width: 1024px) 280px, (min-width: 640px) 45vw, 85vw"
+                          className="object-cover"
+                        />
+                      </div>
+                      <div className="space-y-3">
+                        <div className="flex items-center justify-between text-xs text-white/60">
+                          <span>{vehicle.year}</span>
+                          <span className="rounded-full bg-[#f1c40f]/20 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-[#f1c40f]">
+                            Certificado
+                          </span>
+                        </div>
+                        <h4 className="text-xl font-semibold text-white">{vehicle.model}</h4>
+                        <p className="text-lg font-semibold text-[#f1c40f]">{vehicle.price}</p>
+                        <p className="text-sm text-white/70">{vehicle.description}</p>
+                        <ul className="space-y-2 text-sm text-white/70">
+                          {vehicle.details.map((detail) => (
+                            <li key={detail} className="flex items-center gap-2">
+                              <span className="h-1.5 w-1.5 rounded-full bg-[#f1c40f]" />
+                              {detail}
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    </div>
+                    <button className="mt-6 inline-flex items-center justify-between rounded-full border border-white/10 bg-[#34495e]/60 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-white/80 transition hover:border-[#f1c40f]/40 hover:text-white">
+                      Ver ficha completa
                       <svg
                         className="h-4 w-4"
                         viewBox="0 0 24 24"
@@ -512,58 +555,155 @@ export default function Home() {
                         <path d="M5 12h14" />
                         <path d="m12 5 7 7-7 7" />
                       </svg>
-                    </a>
-                  </div>
-                );
-              })}
-            </div>
-            <div className="rounded-2xl border border-[#f1c40f]/30 bg-[#f1c40f]/10 p-5 text-sm text-white/80">
-              <p className="font-semibold text-[#f1c40f]">Horario extendido</p>
-              <p className="mt-1 text-white/80">Lunes a viernes de 9 a 19 hs · Sábados de 10 a 14 hs.</p>
-              <p className="mt-2 text-white/60">Av. del Libertador 5900 · CABA · +54 11 4567 8900</p>
+                    </button>
+                  </motion.article>
+                ))}
+              </div>
             </div>
           </motion.div>
-        </div>
-      </section>
+        </section>
 
-      <footer className="flex flex-col gap-4 rounded-3xl border border-white/10 bg-black/40 px-8 py-10 text-sm text-white/60">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <p className="text-white/80">
-            © {new Date().getFullYear()} Machine 5900. Concesionaria multimarca · Todos los derechos reservados.
-          </p>
-          <div className="flex flex-wrap gap-3">
-            <Link href="#sobre-nosotros" className="hover:text-white">
-              Sobre nosotros
-            </Link>
-            <Link href="#inventario" className="hover:text-white">
-              Inventario
-            </Link>
-            <Link href="#contacto" className="hover:text-white">
-              Contacto
-            </Link>
+        <section id="marcas" className="section-card space-y-8 px-6 py-10 sm:px-12">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <span className="glass-chip">MARCAS ALIADAS</span>
+              <h2 className="mt-4 text-3xl font-semibold text-white sm:text-4xl">Trabajamos con los mejores fabricantes</h2>
+            </div>
+            <p className="max-w-xl text-sm text-white/60">
+              Nuestro equipo técnico se capacita directamente con cada marca para garantizar diagnósticos precisos, repuestos originales y experiencias de entrega premium.
+            </p>
           </div>
-        </div>
-        <p className="text-xs text-white/40">
-          Diseñado con el ADN Machine: colores icónicos, textura metalizada y animaciones fluidas para una experiencia digital premium.
-        </p>
-      </footer>
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+            {brandLogos.map((brand) => (
+              <div
+                key={brand.name}
+                className="flex items-center justify-center rounded-3xl border border-white/10 bg-white/5 p-6"
+              >
+                <Image
+                  src={brand.image}
+                  alt={`Logo de ${brand.name}`}
+                  width={160}
+                  height={120}
+                  className="h-auto w-32 object-contain sm:w-36"
+                />
+              </div>
+            ))}
+          </div>
+        </section>
 
-      <a
-        href="https://wa.me/5491145678900"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="fixed bottom-6 right-6 inline-flex items-center gap-3 rounded-full bg-[#25d366] px-5 py-3 font-semibold text-[#041007] shadow-[0_20px_45px_-20px_rgba(37,211,102,0.8)] transition hover:scale-105 hover:shadow-[0_30px_60px_-25px_rgba(37,211,102,0.95)]"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 32 32"
-          className="h-5 w-5"
-          fill="currentColor"
-        >
-          <path d="M16.027 3C9.395 3 4 8.395 4 15.027c0 2.653.869 5.11 2.338 7.11L5 29l7.063-1.31A11.96 11.96 0 0 0 16.027 27C22.66 27 28 21.605 28 14.973 28 8.34 22.66 3 16.027 3Zm6.896 16.78c-.28.787-1.64 1.52-2.266 1.61-.58.086-1.327.123-2.14-.134-.493-.156-1.13-.365-1.948-.71-3.43-1.48-5.66-4.94-5.832-5.17-.173-.23-1.395-1.855-1.395-3.54 0-1.685.885-2.513 1.198-2.863.28-.318.745-.463 1.197-.463.145 0 .276.007.396.013.346.015.52.036.75.58.28.675.962 2.337 1.046 2.507.086.173.145.376.026.605-.115.23-.173.375-.347.58-.173.202-.366.454-.523.61-.173.173-.353.362-.152.71.202.347.9 1.48 1.93 2.39 1.33 1.19 2.452 1.56 2.8 1.733.347.173.55.145.75-.086.23-.26.86-1 1.09-1.346.23-.347.462-.288.78-.173.318.115 2.033.96 2.38 1.135.347.173.58.26.665.405.087.144.087.83-.192 1.617Z" />
-        </svg>
-        WhatsApp inmediato
-      </a>
-    </main>
+        <section id="contacto" className="space-y-10">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <span className="glass-chip">CONTACTO</span>
+              <h2 className="mt-4 text-3xl font-semibold text-white sm:text-4xl">Conectá con Machine</h2>
+            </div>
+            <p className="max-w-xl text-sm text-white/60">
+              Elegí la vía que prefieras: escribinos directo por WhatsApp, enviá un formulario o usá nuestras plantillas inteligentes para acelerar tu consulta.
+            </p>
+          </div>
+          <div className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr]">
+            <motion.div
+              initial={{ opacity: 0, y: 30 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, amount: 0.2 }}
+              transition={{ duration: 0.6, ease: "easeOut" }}
+              className="section-card space-y-6 p-8"
+            >
+              <div className="space-y-3">
+                <h3 className="text-xl font-semibold text-white">Vías directas</h3>
+                <p className="text-sm text-white/70">
+                  Respondemos en menos de 10 minutos de lunes a lunes. Coordiná una videollamada, una visita al showroom o una inspección a domicilio.
+                </p>
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <a
+                  href="https://wa.me/5491144444444"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="flex items-center justify-between rounded-2xl border border-[#25D366]/30 bg-[#25D366]/10 px-4 py-3 text-sm font-semibold text-white transition hover:border-[#25D366]/60 hover:bg-[#25D366]/20"
+                >
+                  WhatsApp Machine
+                  <svg
+                    className="h-5 w-5"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M21.5 12a9.5 9.5 0 0 1-13.89 8.31L3 21l.69-4.11A9.5 9.5 0 1 1 21.5 12z" />
+                    <path d="m8.88 9.94.09-.05a2 2 0 0 1 2.58.32l.45.51a2 2 0 0 1 .23 2.36l-.07.12a3.5 3.5 0 0 0 1.27 1.37 4 4 0 0 0 1.79.65 2 2 0 0 1 1.65 2v.11" />
+                  </svg>
+                </a>
+                <a
+                  href="mailto:contacto@machine5900.com"
+                  className="flex items-center justify-between rounded-2xl border border-white/15 bg-white/5 px-4 py-3 text-sm font-semibold text-white transition hover:border-white/30 hover:bg-white/10"
+                >
+                  contacto@machine5900.com
+                  <svg
+                    className="h-5 w-5"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="m4 4 8 8 8-8" />
+                    <path d="M20 4H4v16h16V4Z" />
+                  </svg>
+                </a>
+              </div>
+              <div className="rounded-2xl border border-white/10 bg-white/5 p-5">
+                <h4 className="text-sm font-semibold uppercase tracking-[0.3em] text-white/60">Showroom Machine 5900</h4>
+                <p className="mt-2 text-white/80">Gorriti 5900, Palermo - Buenos Aires</p>
+                <p className="text-sm text-white/60">Lunes a sábado de 10 a 20 hs · Domingos con cita previa</p>
+              </div>
+            </motion.div>
+            <motion.div
+              initial={{ opacity: 0, y: 30 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, amount: 0.2 }}
+              transition={{ duration: 0.6, delay: 0.1, ease: "easeOut" }}
+              className="section-card space-y-6 p-8"
+            >
+              <div className="space-y-3">
+                <h3 className="text-xl font-semibold text-white">Plantillas rápidas</h3>
+                <p className="text-sm text-white/70">
+                  Copiá y pegá en tu mail o WhatsApp y recibí una respuesta personalizada en minutos.
+                </p>
+              </div>
+              <div className="space-y-4">
+                {contactTemplates.map((template) => (
+                  <div key={template.title} className="rounded-2xl border border-white/10 bg-white/5 p-5">
+                    <div className="flex items-center justify-between gap-4">
+                      <div>
+                        <h4 className="text-lg font-semibold text-white">{template.title}</h4>
+                        <p className="text-sm text-white/60">{template.description}</p>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          const subject = encodeURIComponent(template.subject);
+                          const body = encodeURIComponent(template.body);
+                          window.open(`mailto:contacto@machine5900.com?subject=${subject}&body=${body}`);
+                        }}
+                        className="rounded-full border border-white/15 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white/80 transition hover:border-white/30 hover:text-white"
+                      >
+                        Enviar
+                      </button>
+                    </div>
+                    <p className="mt-4 rounded-2xl border border-white/10 bg-black/40 p-4 text-xs font-mono text-white/70">
+                      {template.body}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </motion.div>
+          </div>
+        </section>
+      </main>
+    </div>
   );
 }

--- a/frontend/public/images/hero-garage.svg
+++ b/frontend/public/images/hero-garage.svg
@@ -1,0 +1,55 @@
+<svg width="960" height="640" viewBox="0 0 960 640" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Showroom boutique Machine</title>
+  <desc id="desc">Ilustración de un showroom automotriz iluminado con un deportivo dorado</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1b2735" />
+      <stop offset="55%" stop-color="#0d141d" />
+      <stop offset="100%" stop-color="#05080d" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="10%" r="65%">
+      <stop offset="0%" stop-color="rgba(241,196,15,0.45)" />
+      <stop offset="100%" stop-color="rgba(241,196,15,0)" />
+    </radialGradient>
+    <linearGradient id="car" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#f7d774" />
+      <stop offset="45%" stop-color="#f1c40f" />
+      <stop offset="100%" stop-color="#b8870d" />
+    </linearGradient>
+  </defs>
+  <rect width="960" height="640" fill="url(#bg)" />
+  <rect width="960" height="640" fill="url(#glow)" />
+  <g opacity="0.35">
+    <rect x="80" y="140" width="160" height="280" rx="18" fill="#101a27" />
+    <rect x="280" y="110" width="200" height="320" rx="22" fill="#121f2e" />
+    <rect x="520" y="90" width="180" height="360" rx="26" fill="#132233" />
+    <rect x="740" y="130" width="140" height="300" rx="20" fill="#111c29" />
+  </g>
+  <g transform="translate(140 360)">
+    <path d="M40 88c-6-28 18-60 46-72 72-32 214-30 296-24 48 4 84 24 112 68 16 26 32 46 34 64H40z" fill="#0a1018" opacity="0.75" />
+  </g>
+  <g transform="translate(180 280)">
+    <path d="M60 120c12-52 52-96 124-112 104-24 216-8 296 40 32 20 64 54 60 96H60z" fill="url(#car)" />
+    <path d="M82 118c8-30 42-68 116-82 88-18 182-6 248 34 26 16 48 40 50 70H82z" fill="rgba(255,255,255,0.12)" />
+    <path d="M88 130h432c10 0 18 8 18 18v10c0 6-4 10-10 10H80c-6 0-10-4-10-10v-8c0-10 8-20 18-20z" fill="#0d141d" opacity="0.8" />
+    <g transform="translate(84 164)">
+      <circle cx="74" cy="0" r="48" fill="#090f16" />
+      <circle cx="74" cy="0" r="28" fill="#1f2b3b" />
+      <circle cx="74" cy="0" r="16" fill="#f1c40f" />
+    </g>
+    <g transform="translate(388 164)">
+      <circle cx="74" cy="0" r="48" fill="#090f16" />
+      <circle cx="74" cy="0" r="28" fill="#1f2b3b" />
+      <circle cx="74" cy="0" r="16" fill="#f1c40f" />
+    </g>
+    <path d="M136 58c8-18 40-34 88-38 92-8 204-2 284 28 18 8 40 26 44 48-16 4-64 6-92-12-40-24-108-32-156-22-36 8-92 12-168-4z" fill="rgba(5,8,13,0.6)" />
+  </g>
+  <g opacity="0.4" fill="#f1c40f">
+    <circle cx="120" cy="520" r="3" />
+    <circle cx="200" cy="540" r="2" />
+    <circle cx="320" cy="520" r="4" />
+    <circle cx="520" cy="560" r="3" />
+    <circle cx="680" cy="520" r="2" />
+    <circle cx="820" cy="540" r="4" />
+  </g>
+</svg>

--- a/frontend/public/logos/audi.svg
+++ b/frontend/public/logos/audi.svg
@@ -1,0 +1,9 @@
+<svg width="200" height="80" viewBox="0 0 200 80" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Logo de Audi simplificado</title>
+  <g fill="none" stroke="#d0d0d0" stroke-width="6">
+    <circle cx="50" cy="40" r="28" />
+    <circle cx="96" cy="40" r="28" />
+    <circle cx="142" cy="40" r="28" />
+    <circle cx="188" cy="40" r="28" />
+  </g>
+</svg>

--- a/frontend/public/logos/fiat.svg
+++ b/frontend/public/logos/fiat.svg
@@ -1,0 +1,7 @@
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Logo de Fiat estilizado</title>
+  <rect x="10" y="10" width="100" height="100" rx="18" fill="#a30021" stroke="#ffffff" stroke-width="6" />
+  <text x="60" y="78" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="700" font-size="48" text-anchor="middle" fill="#ffffff">
+    FIAT
+  </text>
+</svg>

--- a/frontend/public/logos/ford.svg
+++ b/frontend/public/logos/ford.svg
@@ -1,0 +1,7 @@
+<svg width="160" height="80" viewBox="0 0 160 80" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Logo de Ford simplificado</title>
+  <ellipse cx="80" cy="40" rx="74" ry="32" fill="#0c3c78" stroke="#ffffff" stroke-width="4" />
+  <text x="80" y="47" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="600" font-size="28" text-anchor="middle" fill="#ffffff">
+    Ford
+  </text>
+</svg>

--- a/frontend/public/logos/jeep.svg
+++ b/frontend/public/logos/jeep.svg
@@ -1,0 +1,7 @@
+<svg width="160" height="80" viewBox="0 0 160 80" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Logo de Jeep minimalista</title>
+  <rect x="10" y="20" width="140" height="40" rx="12" fill="#1b3a1b" />
+  <text x="80" y="48" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="700" font-size="36" text-anchor="middle" fill="#e2f5e2">
+    Jeep
+  </text>
+</svg>

--- a/frontend/public/logos/peugeot.svg
+++ b/frontend/public/logos/peugeot.svg
@@ -1,0 +1,5 @@
+<svg width="140" height="160" viewBox="0 0 140 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Logo de Peugeot reinterpretado</title>
+  <path d="M70 10L120 34V94C120 118 99 146 70 150C41 146 20 118 20 94V34Z" fill="#0b1b36" stroke="#ffffff" stroke-width="6" />
+  <path d="M48 54h12l10 18 10-18h12l-14 24 14 24H80l-10-18-10 18H48l14-24z" fill="#ffffff" />
+</svg>

--- a/frontend/public/logos/renault.svg
+++ b/frontend/public/logos/renault.svg
@@ -1,0 +1,5 @@
+<svg width="120" height="140" viewBox="0 0 120 140" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Logo de Renault geométrico</title>
+  <path d="M60 10L102 70L60 130L18 70Z" fill="#f7c600" stroke="#ffffff" stroke-width="6" />
+  <path d="M60 32L86 70L60 108L34 70Z" fill="#1a1a1a" />
+</svg>

--- a/frontend/public/logos/toyota.svg
+++ b/frontend/public/logos/toyota.svg
@@ -1,0 +1,6 @@
+<svg width="160" height="80" viewBox="0 0 160 80" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Logo de Toyota simplificado</title>
+  <ellipse cx="80" cy="40" rx="68" ry="30" fill="none" stroke="#ffffff" stroke-width="6" />
+  <ellipse cx="80" cy="40" rx="34" ry="24" fill="none" stroke="#ffffff" stroke-width="6" />
+  <ellipse cx="80" cy="40" rx="60" ry="10" fill="none" stroke="#ffffff" stroke-width="6" />
+</svg>

--- a/frontend/public/vehicles/audi-lineup.svg
+++ b/frontend/public/vehicles/audi-lineup.svg
@@ -1,0 +1,38 @@
+<svg width="640" height="360" viewBox="0 0 640 360" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Audi Q5 y A3 sportback exhibidos</title>
+  <defs>
+    <linearGradient id="audiBg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2c2c2c" />
+      <stop offset="100%" stop-color="#111" />
+    </linearGradient>
+    <linearGradient id="audiCar" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#f5f5f5" />
+      <stop offset="100%" stop-color="#b5b5b5" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="360" rx="28" fill="url(#audiBg)" />
+  <g opacity="0.45" fill="#1c1c1c">
+    <rect x="62" y="66" width="92" height="182" rx="18" />
+    <rect x="176" y="58" width="118" height="208" rx="22" />
+    <rect x="314" y="76" width="116" height="190" rx="20" />
+    <rect x="452" y="70" width="124" height="206" rx="24" />
+  </g>
+  <g transform="translate(76 186)">
+    <path d="M18 72c-5-22 16-48 38-58 56-24 168-22 230-18 36 2 68 18 90 48 12 18 22 32 24 46H18z" fill="#080808" opacity="0.6" />
+  </g>
+  <g transform="translate(108 146)">
+    <path d="M38 94c10-40 40-74 96-88 82-18 174-6 236 32 24 14 46 42 44 68H38z" fill="url(#audiCar)" />
+    <path d="M46 96h344c8 0 14 6 14 14v8c0 6-4 10-10 10H40c-6 0-10-4-10-10v-6c0-10 6-16 16-16z" fill="#161616" opacity="0.85" />
+    <g transform="translate(44 128)">
+      <circle cx="56" cy="0" r="36" fill="#080808" />
+      <circle cx="56" cy="0" r="20" fill="#202020" />
+      <circle cx="56" cy="0" r="12" fill="#d0d0d0" />
+    </g>
+    <g transform="translate(260 128)">
+      <circle cx="56" cy="0" r="36" fill="#080808" />
+      <circle cx="56" cy="0" r="20" fill="#202020" />
+      <circle cx="56" cy="0" r="12" fill="#d0d0d0" />
+    </g>
+    <path d="M90 46c6-12 30-22 68-26 70-6 154-2 212 20 12 6 28 18 32 32-12 2-48 4-70-8-30-16-82-22-118-14-28 6-72 8-124-4z" fill="rgba(8,8,8,0.6)" />
+  </g>
+</svg>

--- a/frontend/public/vehicles/fiat-lineup.svg
+++ b/frontend/public/vehicles/fiat-lineup.svg
@@ -1,0 +1,38 @@
+<svg width="640" height="360" viewBox="0 0 640 360" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Fiat Pulse y Cronos listos para entrega</title>
+  <defs>
+    <linearGradient id="fiatBg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#641414" />
+      <stop offset="100%" stop-color="#2a0505" />
+    </linearGradient>
+    <linearGradient id="fiatCar" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#f7a4a4" />
+      <stop offset="100%" stop-color="#c43737" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="360" rx="28" fill="url(#fiatBg)" />
+  <g opacity="0.45" fill="#5a1010">
+    <rect x="60" y="70" width="90" height="176" rx="18" />
+    <rect x="170" y="62" width="110" height="198" rx="22" />
+    <rect x="310" y="80" width="112" height="186" rx="20" />
+    <rect x="446" y="72" width="118" height="204" rx="24" />
+  </g>
+  <g transform="translate(78 182)">
+    <path d="M16 70c-5-20 14-44 36-54 54-24 160-20 222-16 36 2 66 16 88 46 12 16 22 32 24 44H16z" fill="#1a0404" opacity="0.65" />
+  </g>
+  <g transform="translate(106 144)">
+    <path d="M36 92c10-38 38-70 92-84 78-18 166-6 226 32 24 14 46 40 46 66H36z" fill="url(#fiatCar)" />
+    <path d="M44 94h330c8 0 14 6 14 14v8c0 6-4 10-10 10H38c-6 0-10-4-10-10v-6c0-10 6-16 16-16z" fill="#2a0505" opacity="0.8" />
+    <g transform="translate(42 126)">
+      <circle cx="54" cy="0" r="36" fill="#220505" />
+      <circle cx="54" cy="0" r="20" fill="#5f1a1a" />
+      <circle cx="54" cy="0" r="12" fill="#f7a4a4" />
+    </g>
+    <g transform="translate(254 126)">
+      <circle cx="54" cy="0" r="36" fill="#220505" />
+      <circle cx="54" cy="0" r="20" fill="#5f1a1a" />
+      <circle cx="54" cy="0" r="12" fill="#f7a4a4" />
+    </g>
+    <path d="M86 44c6-12 30-22 66-26 68-6 148-2 204 20 12 6 28 18 32 32-12 2-48 4-70-8-30-16-80-20-116-14-26 6-68 8-116-4z" fill="rgba(26,4,4,0.55)" />
+  </g>
+</svg>

--- a/frontend/public/vehicles/ford-lineup.svg
+++ b/frontend/public/vehicles/ford-lineup.svg
@@ -1,0 +1,38 @@
+<svg width="640" height="360" viewBox="0 0 640 360" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Ford Bronco y Mustang en exposición</title>
+  <defs>
+    <linearGradient id="fordBg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0a2a57" />
+      <stop offset="100%" stop-color="#041224" />
+    </linearGradient>
+    <linearGradient id="fordCar" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#4b8bd4" />
+      <stop offset="100%" stop-color="#1b4b8f" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="360" rx="28" fill="url(#fordBg)" />
+  <g opacity="0.45" fill="#0f2744">
+    <rect x="64" y="72" width="96" height="180" rx="18" />
+    <rect x="180" y="60" width="116" height="200" rx="22" />
+    <rect x="320" y="78" width="110" height="188" rx="20" />
+    <rect x="452" y="66" width="120" height="210" rx="24" />
+  </g>
+  <g transform="translate(80 180)">
+    <path d="M18 74c-5-22 16-48 40-58 58-26 172-22 238-18 38 2 70 18 94 52 12 18 22 34 24 48H18z" fill="#020812" opacity="0.65" />
+  </g>
+  <g transform="translate(110 140)">
+    <path d="M40 98c10-42 42-78 100-92 86-18 180-6 246 34 26 16 50 44 48 74H40z" fill="url(#fordCar)" />
+    <path d="M50 100h356c8 0 14 6 14 14v8c0 6-4 10-10 10H44c-6 0-10-4-10-10v-6c0-10 6-16 16-16z" fill="#040b16" opacity="0.8" />
+    <g transform="translate(46 134)">
+      <circle cx="58" cy="0" r="38" fill="#03070d" />
+      <circle cx="58" cy="0" r="22" fill="#102540" />
+      <circle cx="58" cy="0" r="12" fill="#4b8bd4" />
+    </g>
+    <g transform="translate(270 134)">
+      <circle cx="58" cy="0" r="38" fill="#03070d" />
+      <circle cx="58" cy="0" r="22" fill="#102540" />
+      <circle cx="58" cy="0" r="12" fill="#4b8bd4" />
+    </g>
+    <path d="M96 48c6-14 32-26 72-30 74-6 160-2 222 22 14 6 32 18 36 36-14 2-52 4-76-10-32-18-86-24-124-16-28 6-74 10-130-2z" fill="rgba(2,8,18,0.6)" />
+  </g>
+</svg>

--- a/frontend/public/vehicles/jeep-lineup.svg
+++ b/frontend/public/vehicles/jeep-lineup.svg
@@ -1,0 +1,38 @@
+<svg width="640" height="360" viewBox="0 0 640 360" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Jeep Compass y Gladiator listos para la aventura</title>
+  <defs>
+    <linearGradient id="jeepBg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#133016" />
+      <stop offset="100%" stop-color="#050f06" />
+    </linearGradient>
+    <linearGradient id="jeepCar" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#7ad27a" />
+      <stop offset="100%" stop-color="#2f6b2f" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="360" rx="28" fill="url(#jeepBg)" />
+  <g opacity="0.45" fill="#0f2711">
+    <rect x="56" y="74" width="100" height="180" rx="18" />
+    <rect x="176" y="60" width="120" height="208" rx="22" />
+    <rect x="318" y="78" width="120" height="190" rx="20" />
+    <rect x="454" y="70" width="124" height="206" rx="24" />
+  </g>
+  <g transform="translate(74 188)">
+    <path d="M20 74c-5-22 16-48 40-58 58-24 174-22 236-18 38 2 70 18 92 48 12 18 22 32 24 46H20z" fill="#071108" opacity="0.65" />
+  </g>
+  <g transform="translate(108 148)">
+    <path d="M40 96c10-40 40-74 100-88 84-18 178-6 240 32 26 16 48 42 46 70H40z" fill="url(#jeepCar)" />
+    <path d="M48 98h350c8 0 14 6 14 14v8c0 6-4 10-10 10H42c-6 0-10-4-10-10v-6c0-10 6-16 16-16z" fill="#09170b" opacity="0.82" />
+    <g transform="translate(46 130)">
+      <circle cx="58" cy="0" r="38" fill="#050c06" />
+      <circle cx="58" cy="0" r="22" fill="#153b18" />
+      <circle cx="58" cy="0" r="12" fill="#7ad27a" />
+    </g>
+    <g transform="translate(272 130)">
+      <circle cx="58" cy="0" r="38" fill="#050c06" />
+      <circle cx="58" cy="0" r="22" fill="#153b18" />
+      <circle cx="58" cy="0" r="12" fill="#7ad27a" />
+    </g>
+    <path d="M98 48c6-12 32-22 70-26 74-6 162-2 222 20 14 6 30 18 34 32-14 2-50 4-74-8-32-16-86-22-124-14-30 6-76 8-128-4z" fill="rgba(7,17,8,0.6)" />
+  </g>
+</svg>

--- a/frontend/public/vehicles/peugeot-lineup.svg
+++ b/frontend/public/vehicles/peugeot-lineup.svg
@@ -1,0 +1,38 @@
+<svg width="640" height="360" viewBox="0 0 640 360" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Peugeot 3008 y 208 GT listos para entrega</title>
+  <defs>
+    <linearGradient id="peugeotBg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#051c3b" />
+      <stop offset="100%" stop-color="#020910" />
+    </linearGradient>
+    <linearGradient id="peugeotCar" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#7fb4ff" />
+      <stop offset="100%" stop-color="#2356a4" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="360" rx="28" fill="url(#peugeotBg)" />
+  <g opacity="0.45" fill="#0a274c">
+    <rect x="60" y="70" width="98" height="182" rx="18" />
+    <rect x="178" y="60" width="120" height="206" rx="22" />
+    <rect x="318" y="80" width="116" height="188" rx="20" />
+    <rect x="454" y="72" width="124" height="204" rx="24" />
+  </g>
+  <g transform="translate(78 184)">
+    <path d="M18 72c-5-22 16-48 40-58 58-24 172-22 236-18 38 2 70 18 92 48 12 18 22 32 24 46H18z" fill="#030910" opacity="0.65" />
+  </g>
+  <g transform="translate(110 146)">
+    <path d="M40 94c10-40 40-74 100-88 84-18 178-6 240 32 26 14 48 42 46 68H40z" fill="url(#peugeotCar)" />
+    <path d="M48 96h348c8 0 14 6 14 14v8c0 6-4 10-10 10H42c-6 0-10-4-10-10v-6c0-10 6-16 16-16z" fill="#051830" opacity="0.82" />
+    <g transform="translate(46 128)">
+      <circle cx="58" cy="0" r="38" fill="#020b15" />
+      <circle cx="58" cy="0" r="22" fill="#10335c" />
+      <circle cx="58" cy="0" r="12" fill="#7fb4ff" />
+    </g>
+    <g transform="translate(274 128)">
+      <circle cx="58" cy="0" r="38" fill="#020b15" />
+      <circle cx="58" cy="0" r="22" fill="#10335c" />
+      <circle cx="58" cy="0" r="12" fill="#7fb4ff" />
+    </g>
+    <path d="M98 48c6-12 32-22 70-26 74-6 162-2 224 20 14 6 30 18 34 32-14 2-50 4-74-8-32-16-88-22-126-14-30 6-76 8-128-4z" fill="rgba(3,9,16,0.6)" />
+  </g>
+</svg>

--- a/frontend/public/vehicles/renault-lineup.svg
+++ b/frontend/public/vehicles/renault-lineup.svg
@@ -1,0 +1,38 @@
+<svg width="640" height="360" viewBox="0 0 640 360" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Renault Alaskan y Stepway certificadas</title>
+  <defs>
+    <linearGradient id="renaultBg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#403000" />
+      <stop offset="100%" stop-color="#1a1400" />
+    </linearGradient>
+    <linearGradient id="renaultCar" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#ffe680" />
+      <stop offset="100%" stop-color="#d7a10a" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="360" rx="28" fill="url(#renaultBg)" />
+  <g opacity="0.45" fill="#332400">
+    <rect x="58" y="70" width="96" height="182" rx="18" />
+    <rect x="174" y="62" width="118" height="202" rx="22" />
+    <rect x="312" y="80" width="114" height="190" rx="20" />
+    <rect x="450" y="70" width="122" height="206" rx="24" />
+  </g>
+  <g transform="translate(74 186)">
+    <path d="M20 72c-5-22 16-48 38-58 56-24 170-22 234-18 36 2 68 18 90 48 12 18 22 32 24 46H20z" fill="#120d00" opacity="0.6" />
+  </g>
+  <g transform="translate(108 146)">
+    <path d="M40 94c10-40 40-74 98-88 82-18 176-6 236 32 26 14 48 42 46 68H40z" fill="url(#renaultCar)" />
+    <path d="M48 96h344c8 0 14 6 14 14v8c0 6-4 10-10 10H42c-6 0-10-4-10-10v-6c0-10 6-16 16-16z" fill="#1f1500" opacity="0.82" />
+    <g transform="translate(46 128)">
+      <circle cx="56" cy="0" r="36" fill="#120d00" />
+      <circle cx="56" cy="0" r="20" fill="#423100" />
+      <circle cx="56" cy="0" r="12" fill="#ffe680" />
+    </g>
+    <g transform="translate(262 128)">
+      <circle cx="56" cy="0" r="36" fill="#120d00" />
+      <circle cx="56" cy="0" r="20" fill="#423100" />
+      <circle cx="56" cy="0" r="12" fill="#ffe680" />
+    </g>
+    <path d="M94 48c6-12 30-22 68-26 72-6 158-2 214 20 12 6 30 18 34 32-12 2-48 4-70-8-32-16-84-22-120-14-28 6-72 8-126-4z" fill="rgba(18,13,0,0.6)" />
+  </g>
+</svg>

--- a/frontend/public/vehicles/toyota-lineup.svg
+++ b/frontend/public/vehicles/toyota-lineup.svg
@@ -1,0 +1,38 @@
+<svg width="640" height="360" viewBox="0 0 640 360" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Toyota Corolla y SW4 certificados</title>
+  <defs>
+    <linearGradient id="toyotaBg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#5c0a0a" />
+      <stop offset="100%" stop-color="#1a0202" />
+    </linearGradient>
+    <linearGradient id="toyotaCar" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#ffdfdf" />
+      <stop offset="100%" stop-color="#ff7b7b" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="360" rx="28" fill="url(#toyotaBg)" />
+  <g opacity="0.45" fill="#460909">
+    <rect x="58" y="72" width="96" height="182" rx="18" />
+    <rect x="174" y="64" width="118" height="202" rx="22" />
+    <rect x="314" y="82" width="114" height="188" rx="20" />
+    <rect x="450" y="72" width="122" height="206" rx="24" />
+  </g>
+  <g transform="translate(76 186)">
+    <path d="M18 72c-5-22 16-48 38-58 56-24 168-22 232-18 36 2 68 18 92 48 12 18 22 32 24 46H18z" fill="#140303" opacity="0.6" />
+  </g>
+  <g transform="translate(108 146)">
+    <path d="M38 94c10-40 40-74 98-88 82-18 176-6 238 32 26 14 48 42 46 68H38z" fill="url(#toyotaCar)" />
+    <path d="M46 96h346c8 0 14 6 14 14v8c0 6-4 10-10 10H40c-6 0-10-4-10-10v-6c0-10 6-16 16-16z" fill="#2a0404" opacity="0.82" />
+    <g transform="translate(44 128)">
+      <circle cx="56" cy="0" r="36" fill="#120202" />
+      <circle cx="56" cy="0" r="20" fill="#501010" />
+      <circle cx="56" cy="0" r="12" fill="#ffb7b7" />
+    </g>
+    <g transform="translate(262 128)">
+      <circle cx="56" cy="0" r="36" fill="#120202" />
+      <circle cx="56" cy="0" r="20" fill="#501010" />
+      <circle cx="56" cy="0" r="12" fill="#ffb7b7" />
+    </g>
+    <path d="M92 48c6-12 30-22 68-26 72-6 158-2 216 20 12 6 30 18 34 32-12 2-48 4-72-8-32-16-84-22-120-14-28 6-72 8-126-4z" fill="rgba(20,3,3,0.55)" />
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add a fixed top navigation bar with quick anchors and adjust hero with a curated showroom image
- refresh the inventory to focus on Ford, Fiat, Audi, Jeep, Toyota, Renault and Peugeot with descriptions and illustrations per modelo
- highlight partner brands through a dedicated logo grid and add bespoke SVG assets for hero, vehículos y logos

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68d473fa4e04832289aef4d6522e989f